### PR TITLE
Investigate api no content redirection error

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -30,7 +30,6 @@ export const appConfig: ApplicationConfig = {
             withPreloading(PreloadAllModules),
             withInMemoryScrolling({scrollPositionRestoration: 'enabled'}),
         ),
-		{ provide: API_BASE_HREF, useFactory: getBaseLocation },
         { provide: API_BASE_HREF, useFactory: getApiBase },
 
         // Material Date Adapter

--- a/src/app/services/frame-api.service.ts
+++ b/src/app/services/frame-api.service.ts
@@ -20,7 +20,7 @@ export class FrameApiService {
         quality: string = 'compressed'
     ) {
         return this.http.get(
-            `/api/jobs/${jobId}/data?number=${frameNumber.toString()}&type=${type}&quality=${quality}&org=`,
+            `${this.baseUrl}api/jobs/${jobId}/data?number=${frameNumber.toString()}&type=${type}&quality=${quality}&org=`,
             {
                 withCredentials: true,
                 responseType: 'blob',
@@ -30,7 +30,7 @@ export class FrameApiService {
 
     getMeta(job_id: number, frame_number: number): Observable<FrameData> {
         return this.http.get<FrameData>(
-            `/api/custom/jobs/${job_id}/frame/${frame_number}`
+            `${this.baseUrl}api/custom/jobs/${job_id}/frame/${frame_number}`
         );
     }
 }


### PR DESCRIPTION
Resolve API redirect errors by consolidating `API_BASE_HREF` providers and ensuring consistent base URL usage in `FrameApiService`.

The previous configuration had a duplicate `API_BASE_HREF` provider, leading to conflicts, and `FrameApiService` was not consistently prepending the base URL to its API calls. This resulted in malformed requests that the server would redirect, causing "no content" responses when the client expected a blob.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ad98549-cd04-4f7d-b5aa-afc19c926e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ad98549-cd04-4f7d-b5aa-afc19c926e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

